### PR TITLE
Fixes for building on FreeBSD

### DIFF
--- a/OpenClaw/Engine/GameApp/BaseGameApp.cpp
+++ b/OpenClaw/Engine/GameApp/BaseGameApp.cpp
@@ -622,9 +622,9 @@ bool BaseGameApp::InitializeDisplay(GameOptions& gameOptions)
 {
     LOG(">>>>> Initializing display...");
 
-    if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
+    if (SDL_Init(SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_VIDEO) != 0)
     {
-        LOG_ERROR("Failed to initialize SDL2 library");
+        LOG_ERROR("Failed to initialize SDL2 library. Error: %s" + std::string(SDL_GetError()));
         return false;
     }
 

--- a/OpenClaw/Engine/GameApp/MainLoop.cpp
+++ b/OpenClaw/Engine/GameApp/MainLoop.cpp
@@ -2,7 +2,7 @@
 #include "MainLoop.h"
 #include <fstream>
 
-#if defined __LINUX__ && __LINUX__ == 1
+#if !(defined(__ANDROID__) || defined(__WINDOWS__))
 #include <pwd.h>
 #include <unistd.h>
 #endif
@@ -16,9 +16,11 @@ int RunGameEngine(int argc, char** argv)
 
     std::string userDirectory = "";
 
-#if defined __ANDROID__ && __ANDROID__ == 1
+#if defined(__ANDROID__)
     userDirectory = "/sdcard/claw/";
-#elif defined __LINUX__ && __LINUX__ == 1
+#elif defined(__WINDOWS__)
+    userDirectory = "";
+#else
     const char* homedir;
 
     if ((homedir = getenv("HOME")) == NULL) 
@@ -29,8 +31,6 @@ int RunGameEngine(int argc, char** argv)
 
     userDirectory = std::string(homedir) + "/.config/openclaw/";
 
-#elif defined __WINDOWS__ && _WINDOWS__ == 1
-    configDir = "";
 #endif
 
     LOG("Looking for: " + userDirectory + "config.xml");


### PR DESCRIPTION
SDL_INIT_EVERYTHING initializes *everything*, including subsystems which were not enabled in the SDL2 build. So it always fails because the haptic feedback subsystem is disabled by default in FreeBSD ports.

Also replace `__LINUX__` with "not Android or Windows".