### PR TITLE
Controls for taking actions for both left/right control, shift and alt keys.

### DIFF
--- a/OpenClaw/ActorController.cpp
+++ b/OpenClaw/ActorController.cpp
@@ -136,17 +136,17 @@ bool ActorController::VOnKeyDown(SDL_Keycode key)
     }
     else
     {
-        if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LALT)
+        if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LALT || SDL_GetScancodeFromKey(key) == SDL_SCANCODE_RALT)
         {
             HandleAction(ActionType_Fire);
             return true;
         }
-        else if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LCTRL)
+        else if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LCTRL || SDL_GetScancodeFromKey(key) == SDL_SCANCODE_RCTRL)
         {
             HandleAction(ActionType_Attack);
             return true;
         }
-        else if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LSHIFT)
+        else if (SDL_GetScancodeFromKey(key) == SDL_SCANCODE_LSHIFT || SDL_GetScancodeFromKey(key) == SDL_SCANCODE_RSHIFT)
         {
             HandleAction(ActionType_Change_Ammo_Type);
             return true;


### PR DESCRIPTION
Hey, remember when I contacted you telling you that I wanted to contribute as well? So I decided to start small. I have a few simple ideas due to the features I remember about the game. For example, it is possible to fire a continuous stream of bullets(press down alt) but not a continuous stream of magic claws(basically check what attack we have set - dynamite, magic or bullets). If bullets and alt press => Stream. Another one is picking up and throwing enemies and objects. I have got a few ideas about some of the bugs as well(apologies for writing all this in a PR lol). Also, I mistakenly added the binary in the first commit so I removed it in the 2nd one.